### PR TITLE
Some time_entries does not have any comments

### DIFF
--- a/app/views/issues/_history.html.erb
+++ b/app/views/issues/_history.html.erb
@@ -68,13 +68,15 @@ if User.current.allowed_to?(:view_time_entries, @project)
 		c << '<li>'
 				c << "<strong>" + l(:label_history_time_spent) + ":</strong> " + html_hours("%.2f" % timelog.hours) + " " + l(:label_history_time_hours_on) + " " + h(timelog.activity)
 		c << '</li>'
-			unless timelog.comments.empty?
-				c << '<blockquote>'
-					c << '<p>'
-					c << timelog.comments 
-				c << '</p>'
-			c << '</blockquote>'
-			c << '</li>'
+			if timelog.comments.nil?
+				unless timelog.comments.empty?
+					c << '<blockquote>'
+						c << '<p>'
+						c << timelog.comments 
+					c << '</p>'
+				c << '</blockquote>'
+				c << '</li>'
+				end
 			end
 		c << '</ul>'
 	c << '</div>'


### PR DESCRIPTION
On redmine 2.6.3 i tried to install this plugin, but got the error 
<pre>
ActionView::Template::Error (undefined method `empty?' for nil:NilClass):
    68:         c << '<li>'
    69:                 c << "<strong>" + l(:label_history_time_spent) + ":</strong> " + html_hours("%.2f" % timelog.hours) + " " + l(:label_history_time_hours_on) + " " + h(timelog.activity)
    70:         c << '</li>'
    71:             unless timelog.comments.empty?
    72:                 c << '<blockquote>'
    73:                     c << '<p>'
    74:                     c << timelog.comments 
  app/views/issues/show.html.erb:126:in`_app_views_issues_show_html_erb___740572923_59739972'
  app/controllers/issues_controller.rb:128:in `block (2 levels) in show'
  app/controllers/issues_controller.rb:125:in`show'
</pre

To avoid this error i put a <pre>if timelog.comments.nil?</pre>.
